### PR TITLE
manifest: Jenkins is dead

### DIFF
--- a/snippets/lineage.xml
+++ b/snippets/lineage.xml
@@ -114,7 +114,7 @@
   <project path="lineage/charter" name="LineageOS/charter" groups="infra" revision="master" />
   <project path="lineage/crowdin" name="LineageOS/cm_crowdin" groups="infra" revision="master" />
   <project path="lineage/cve" name="LineageOS/cve_tracker" groups="infra" revision="master" />
-  <project path="lineage/jenkins" name="LineageOS/hudson" groups="infra" revision="master" />
+  <project path="lineage/hudson" name="LineageOS/hudson" groups="infra" revision="master" />
   <project path="lineage/mirror" name="LineageOS/mirror" groups="infra" revision="master" />
   <project path="lineage/slackbot" name="LineageOS/slackbot" groups="infra" revision="master" />
   <project path="lineage/website" name="LineageOS/www" groups="infra" revision="master" />


### PR DESCRIPTION
* We use Gitlab builds now.
* Jenkins references now removed from the Wiki.

Change-Id: Iaf8b7ce8e266096cf2178ec75aac6a19c87035e6